### PR TITLE
incVersion.sh: Use committed date instead authored date for timestamp

### DIFF
--- a/incVersion.sh
+++ b/incVersion.sh
@@ -64,9 +64,9 @@ if [ -z "$version" ] ; then
       [[ $(pwd) == */ngfw_upstream/* ]] && d=.. || d=.
       revision=$(git log -n 1 --format="%h" -- $d)
       # older git versions don't have --date=iso-strict-local, so we
-      # use --date=local (to convert to local timezone) with %ad,
+      # use --date=local (to convert to local timezone) with %cd,
       # which yields something like "Tue Sep 13 23:46:56 PDT 2016"
-      timestamp="$(git log -n 1 --date=local --format='%ad' -- $d)"
+      timestamp="$(git log -n 1 --date=local --format='%cd' -- $d)"
       # ... then we convert that to something like
       # "2016-09-13T23:46:56-0700"
       timestamp=$(date -d"$timestamp" --iso-8601=seconds)


### PR DESCRIPTION
If a commit is pushed with an authored date in the past the resulting
package might be ignored as old even though it may include the latest
code available.

Example:

The following commit was pushed to ngfw_pkgs:

https://github.com/untangle/ngfw_pkgs/commit/93b355318a7021581a46222c20c758eb0e26e455

Its authored date is: Fri Mar 23 15:13:55 2018

But it was pushed to github on (its committed date): Wed Mar 28 09:19:05 2018

Pushing the commit generated a build and the untangle-sync-settings package
was built successfully:

http://build-master-stretch.untangle.int:8010/builders/amd64-build-master_stretch/builds/1125

The package was labeled:

14.0.0.20180323T1213550700.93b355318-1stretch

93b355318 was the commit hash for the latest commit, but the date that
precedes it was 5 days in the past.

Doing an 'apt-get update; apt-cache show untangle-sync-settings' after this
build still yielded 14.0.0.20180328T0420040700.64aabf0ab-1stretch as the
latest untangle-sync-settings package available because its date is after
that of the latest package built.

If the intent is for the latest package available to refer to that package
built from the latest code committed to the github repository, then the
timestamp should be generated from the commit date of the commit instead of
the author date.