### PR TITLE
[EFW-1994] Zuul who am i wget

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -158,6 +158,13 @@ do-build() {
       fi
 
       if [[ -n "$dput_profile" ]] ; then
+
+  # we message the server so that it logs our IP
+  # if we hit the wall with ACL the admin can check error logs
+  # for the given timestamp from the job and see the IP
+  apt install -y wget
+  wget http://package-server.untangle.int/whoami_zuul || true
+
 	apt install -y dput
 	dput -c ${PKGTOOLS}/dput.cf $dput_profile $changes_file || reason="FAILURE"
       fi


### PR DESCRIPTION
https://awakesecurity.atlassian.net/browse/EFW-1994

who am I call to package server

If we hit an ACL wall, we need to know the Zuul IP address visible for the package server to whitelist it.
Thanks to the trick below, it will be in the web server logs with a 404 status code.

Then based on Zuul logs we can check the timestamp of the request and speak with admin about whitelisting the source IP address