### PR TITLE
NGFW-15693: NGFW-15693: Override DISTRIBUTION for Zuul builds on release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -204,6 +204,12 @@ fi
 # set base distribution if none was passed
 if [[ -z "$DISTRIBUTION" ]] ; then
   DISTRIBUTION=$(cat $PKGTOOLS/resources/DISTRIBUTION)
+  # For Zuul builds where pkgtools is fetched at a fixed commit,
+  # DISTRIBUTION may be "current" even on a release branch. Override
+  # using TRAVIS_BRANCH if it matches a release branch pattern.
+  if [[ "$DISTRIBUTION" == "current" && "$TRAVIS_BRANCH" =~ ^ngfw-release- ]] ; then
+    DISTRIBUTION="$TRAVIS_BRANCH"
+  fi
 fi
 
 # set target distribution for PRs


### PR DESCRIPTION
When Zuul builds Gerrit repos (sync-settings, bctid) on release branches, pkgtools is fetched at a fixed commit where DISTRIBUTION=current. This causes packages to land in the wrong reprepro distribution. Fall back to TRAVIS_BRANCH when it matches ngfw-release-* pattern.