### PR TITLE
ngfw-15944: Improved Merge Failure Logging in Compare Branch Script

### DIFF
--- a/compare-branches.py
+++ b/compare-branches.py
@@ -113,7 +113,8 @@ def merge(repository: str, branchFrom: str, branchTo: str) -> Tuple[bool, str]:
         status = "DONE: commitId=" + jsonData["sha"]
     else:
         success = False
-        status = "FAILED: conflicts"
+        error_msg = jsonData.get("message", "unknown error") if jsonData else "no response body"
+        status = f"FAILED (HTTP {sc}): {error_msg}"
 
     return success, status
 


### PR DESCRIPTION
Updated the compare branch script to log the exact HTTP error returned by GitHub instead of reporting every merge failure as a conflict.

## Before

Previously, merge failures were reported generically as conflicts:

```
ngfw_pkgs
    merge FAILED: conflicts

    01 ahead, 14 behind !!! Need to merge !!!
```

## After

The script now reports the actual HTTP status and error message returned by GitHub:

```
ngfw_pkgs
    merge FAILED (HTTP 409): Repository rule violations found

Changes must be made through a pull request.

    01 ahead, 14 behind !!! Need to merge !!!
```

This makes Jenkins failures easier to troubleshoot by providing the actual reason for the merge failure instead of only reporting it as a conflict.